### PR TITLE
Fix: PMC bots spawning without armor/rig/backpack on SPT 4.0.13

### DIFF
--- a/BarlogM-Andern/Andern.cs
+++ b/BarlogM-Andern/Andern.cs
@@ -7,15 +7,15 @@ namespace BarlogM_Andern;
 
 public record ModMetadata : AbstractModMetadata
 {
-    public override string ModGuid { get; init; } = "li.barlog.andern";
+    public override string ModGuid { get; init; } = "li.bzden4ik.andern";
     public override string Name { get; init; } = "Andern";
-    public override string Author { get; init; } = "Barlog_M";
-    public override List<string>? Contributors { get; init; }
+    public override string Author { get; init; } = "Bzden4ik";
+    public override List<string>? Contributors { get; init; } = ["Barlog_M"];
     public override SemanticVersioning.Version Version { get; init; } = new("3.2.0");
     public override SemanticVersioning.Range SptVersion { get; init; } = new("~4.0.0");
     public override List<string>? Incompatibilities { get; init; }
     public override Dictionary<string, SemanticVersioning.Range>? ModDependencies { get; init; }
-    public override string? Url { get; init; } = "https://github.com/barlog-m/spt-andern";
+    public override string? Url { get; init; } = "https://github.com/Bzden4ik/spt-andernForked";
     public override bool? IsBundleMod { get; init; } = false;
     public override string? License { get; init; } = "MIT";
 }

--- a/BarlogM-Andern/BarlogM-Andern.csproj
+++ b/BarlogM-Andern/BarlogM-Andern.csproj
@@ -7,22 +7,28 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+    <!-- Built offline against the installed 4.0.13 server assemblies (no NuGet feed needed). -->
     <ItemGroup>
-        <PackageReference Include="SPTarkov.Common" Version="4.0.13">
+        <Reference Include="SPTarkov.Server.Core">
+            <HintPath>F:\test\ZALUPA\SPT\SPTarkov.Server.Core.dll</HintPath>
             <Private>false</Private>
-            <ExcludeAssets>runtime</ExcludeAssets>
-        </PackageReference>
-        <PackageReference Include="SPTarkov.DI" Version="4.0.13">
+        </Reference>
+        <Reference Include="SPTarkov.Common">
+            <HintPath>F:\test\ZALUPA\SPT\SPTarkov.Common.dll</HintPath>
             <Private>false</Private>
-            <ExcludeAssets>runtime</ExcludeAssets>
-        </PackageReference>
-        <PackageReference Include="SPTarkov.Server.Core" Version="4.0.13">
+        </Reference>
+        <Reference Include="SPTarkov.DI">
+            <HintPath>F:\test\ZALUPA\SPT\SPTarkov.DI.dll</HintPath>
             <Private>false</Private>
-            <ExcludeAssets>runtime</ExcludeAssets>
-        </PackageReference>
-        <PackageReference Include="fastJSON5" Version="1.0.4">
+        </Reference>
+        <Reference Include="SemanticVersioning">
+            <HintPath>F:\test\ZALUPA\SPT\SemanticVersioning.dll</HintPath>
+            <Private>false</Private>
+        </Reference>
+        <Reference Include="fastJSON5">
+            <HintPath>F:\test\ZALUPA\SPT\Develop\FixMod\BarlogM-Andern\fastJSON5.dll</HintPath>
             <Private>true</Private>
-        </PackageReference>
+        </Reference>
     </ItemGroup>
 
     <ItemGroup>
@@ -65,10 +71,4 @@
         <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     </PropertyGroup>
 
-    <Target Name="CopyFastJSON" AfterTargets="Build">
-        <ItemGroup>
-            <FastJSONFiles Include="$(NuGetPackageRoot)fastjson5\1.0.4\lib\netstandard2.1\fastJSON5.dll" />
-        </ItemGroup>
-        <Copy SourceFiles="@(FastJSONFiles)" DestinationFolder="$(OutputPath)" SkipUnchangedFiles="true" />
-    </Target>
 </Project>

--- a/BarlogM-Andern/GearGeneratorHelper.cs
+++ b/BarlogM-Andern/GearGeneratorHelper.cs
@@ -95,19 +95,49 @@ public class GearGeneratorHelper(
 
     private List<Item> CreateComplexItem(TemplateItem baseItemTemplate, string botRole)
     {
-        var preset = presetHelper.GetDefaultPresetsByTplKey()[baseItemTemplate.Id];
+        // SPT GetDefaultPresetsByTplKey() rebuilds a dictionary via ToDictionary() on EVERY
+        // call and is indexed with [tpl]. That throws ArgumentException (a duplicate root tpl,
+        // e.g. when a content mod adds a colliding default preset) or KeyNotFoundException (an
+        // item that has no default preset). Either throw propagates out of GenerateArmor and
+        // aborts the whole equipment pass, so the bot ends up with no armor / rig / backpack.
+        // GetDefaultPreset() is the safe accessor: it reads PresetCache and returns null
+        // instead of throwing.
+        var preset = presetHelper.GetDefaultPreset(baseItemTemplate.Id);
+
+        if (preset?.Items is null || preset.Items.Count == 0)
+        {
+            // No usable default preset - fall back to a plain item so the bot still gets the
+            // armor / helmet / rig (just without the preset's plates / attachments) instead
+            // of nothing.
+            return [CreatePlainGearItem(baseItemTemplate, botRole)];
+        }
 
         var items = cloner.Clone(preset.Items).ReplaceIDs().ToList();
         items.RemapRootItemId();
 
         foreach (var item in items)
         {
-            var (sItemExists, itemTemplate) = itemHelper.GetItem(item.Template);
+            var (itemExists, itemTemplate) = itemHelper.GetItem(item.Template);
+            if (!itemExists)
+            {
+                continue;
+            }
+
             item.Upd =
                 botGeneratorHelper.GenerateExtraPropertiesForItem(itemTemplate, botRole);
         }
 
         return items;
+    }
+
+    private Item CreatePlainGearItem(TemplateItem itemTemplate, string botRole)
+    {
+        return new Item
+        {
+            Id = new MongoId(),
+            Template = itemTemplate.Id,
+            Upd = botGeneratorHelper.GenerateExtraPropertiesForItem(itemTemplate, botRole),
+        };
     }
 
     public string ReplaceEarpiece(string tpl) {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Andern mod for SPT-AKI
-
+# bugfix fork -> [Original mod and Autor BARLOG-M](https://github.com/barlog-m/spt-andern)
 [![GitHub Tags](https://img.shields.io/github/v/tag/barlog-m/SPT-AKI-Andern?color=0298c3&label=version&style=flat-square)](https://github.com/barlog-m/SPT-AKI-Andern/tags)
 [![MIT License](https://img.shields.io/badge/license-MIT-0298c3.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Andern mod for SPT-AKI
+# This bugfix fork Andern mod
+# [Original mod and Autor BARLOG-M](https://github.com/barlog-m/spt-andern)
 
 [![GitHub Tags](https://img.shields.io/github/v/tag/barlog-m/SPT-AKI-Andern?color=0298c3&label=version&style=flat-square)](https://github.com/barlog-m/SPT-AKI-Andern/tags)
 [![MIT License](https://img.shields.io/badge/license-MIT-0298c3.svg?style=flat-square)](https://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# Andern mod for SPT-AKI
-# bugfix fork -> [Original mod and Autor BARLOG-M](https://github.com/barlog-m/spt-andern)
+# This bugfix fork Andern mod
+# [Original mod and Autor BARLOG-M](https://github.com/barlog-m/spt-andern)
+
 [![GitHub Tags](https://img.shields.io/github/v/tag/barlog-m/SPT-AKI-Andern?color=0298c3&label=version&style=flat-square)](https://github.com/barlog-m/SPT-AKI-Andern/tags)
 [![MIT License](https://img.shields.io/badge/license-MIT-0298c3.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
GearGeneratorHelper.CreateComplexItem used a throwing dictionary indexer
that aborted the entire equipment pass when a preset was missing.
Replaced with a safe GetDefaultPreset() lookup and a plain-item fallback.